### PR TITLE
Fix uncaught promise, checks activated before using service #4

### DIFF
--- a/lib/debug-ui.js
+++ b/lib/debug-ui.js
@@ -110,7 +110,7 @@ class AtomDebugUI {
     this._subscriptions.add(atom.config.observe("atom-debug-ui.gutters.gutterBreakpointToggle", (newValue) => {
       const serviceManagers = this._serviceRegistry.getAllServices()
       for (let serviceManager of serviceManagers) {
-        if (serviceManager.hasService("DebugView")) {
+        if (serviceManager.isActivated() && serviceManager.hasService("DebugView")) {
           serviceManager.getDebugViewService().createGutters(newValue)
         }
       }
@@ -119,7 +119,7 @@ class AtomDebugUI {
     this._subscriptions.add(atom.config.observe("atom-debug-ui.gutters.gutterPosition", (newValue) => {
       const serviceManagers = this._serviceRegistry.getAllServices()
       for (let serviceManager of serviceManagers) {
-        if (serviceManager.hasService("DebugView")) {
+        if (serviceManager.isActivated() && serviceManager.hasService("DebugView")) {
           serviceManager.getDebugViewService().createGutters(atom.config.get('atom-debug-ui.gutters.gutterBreakpointToggle'),true)
         }
       }
@@ -129,7 +129,7 @@ class AtomDebugUI {
       if (atom.config.get('atom-debug-ui.gutters.gutterBreakpointToggle')) {
         const serviceManagers = this._serviceRegistry.getAllServices()
         for (let serviceManager of serviceManagers) {
-          if (serviceManager.hasService("DebugView")) {
+          if (serviceManager.isActivated() && serviceManager.hasService("DebugView")) {
             serviceManager.getDebugViewService().createGutter(editor)
           }
         }


### PR DESCRIPTION
Had the same problem as the issue, instead I reproduced it by trying to open the atom-narrow pane, which would not work (breaks other packages) and logs a unspecific error message to the console. Those with the issue could reproduce it by trying to create a new tab using e.g. `ctrl+n` and have it appear in the console.

```
Uncaught (in promise) Cannot get services before activation
```
![image](https://user-images.githubusercontent.com/9924643/146637184-046784ec-d6a1-4e48-b8ef-18f393a9107a.png)

Thought it might have been something to do with services and listeners/events so down I dug and I seemed to have found it.

Personally, I only needed to add the check for the last subscription:
```
this._subscriptions.add(atom.workspace.observeTextEditors((editor) => {
```
...to resolve the issues I was facing, but for the sake of consistency I've added the check to the other similar places too.

Closes #4 